### PR TITLE
Using jquery and fullpage.js

### DIFF
--- a/app/js/controllers/example.js
+++ b/app/js/controllers/example.js
@@ -8,6 +8,14 @@ function ExampleCtrl() {
   vm.title = 'AngularJS, Gulp, and Browserify! Written with keyboards and love!';
   vm.number = 1234;
 
+
+  vm.mainOptions = {
+    sectionsColor: ['#1bbc9b', '#4BBFC3', '#7BAABE'],
+    navigation: true,
+    navigationPosition: 'right',
+    scrollingSpeed: 1000
+  }
+
 }
 
 export default {

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -1,6 +1,9 @@
 'use strict';
 
+import $ from 'jquery'; //we need to load jquery first so angular boots with jquery selector support (angular.element(...))
 import angular from 'angular';
+import 'fullpage.js'; //load fullpage before angular-fullpage
+import 'angular-fullpage.js';
 
 // angular modules
 import 'angular-ui-router';
@@ -17,7 +20,8 @@ const requires = [
   'app.filters',
   'app.controllers',
   'app.services',
-  'app.directives'
+  'app.directives',
+  'fullPage.js'
 ];
 
 // mount on window for testing

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -5,5 +5,19 @@ body {
   font-family: Helvetica, sans-serif;
   color: $font-color--dark;
   background-color: $background--light;
-  padding: $half-space;
+  padding: 0;
+  margin: 0;
+}
+
+.section {
+
+  /* removes margin collapse on sections */
+  & {
+    display: inline-block;
+    width: 100%;
+  }
+  /* added padding that was removed from body */
+  & {
+    padding: $half-space;
+  }
 }

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -1,7 +1,13 @@
-<h1 class="heading -large">{{ home.title | ExampleFilter }}</h1>
-
-<h3 class="heading -medium">Here is a fancy number served up courtesy of Angular: <span class="number-example">{{ home.number }}</span></h3>
-
-<img src="images/angular.png" height="100" example-directive />
-<img src="images/gulp.png" height="100" />
-<img src="images/browserify.png" height="100" />
+<div full-page options="home.mainOptions">
+    <div class="section">
+        <h1 class="heading -large">{{ home.title | ExampleFilter }}</h1>
+    </div>
+    <div class="section">
+        <h3 class="heading -medium">Here is a fancy number served up courtesy of Angular: <span class="number-example">{{ home.number }}</span></h3>
+    </div>
+    <div class="section">
+        <img src="images/angular.png" height="100" example-directive />
+        <img src="images/gulp.png" height="100" />
+        <img src="images/browserify.png" height="100" />
+    </div>
+</div>

--- a/bower.json
+++ b/bower.json
@@ -28,8 +28,10 @@
   ],
   "dependencies": {
     "jquery": "~2.1.4",
+    "fullpage.js": "fullpage#~2.7.4",
     "angular": "~1.4.8",
     "angular-ui-router": "~0.2.15",
     "angular-mocks": "~1.4.8",
+    "angular-fullpage.js": "~0.2.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "tests"
   ],
   "dependencies": {
+    "jquery": "~2.1.4",
     "angular": "~1.4.8",
     "angular-ui-router": "~0.2.15",
     "angular-mocks": "~1.4.8",

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,34 @@
+{
+  "name": "angularjs-gulp-browserify-boilerplate",
+  "description": "Boilerplate using AngularJS, SASS, Gulp, and Browserify while also utilizing best practices.",
+  "main": "",
+  "authors": [
+    "Jake Marsh <jakemmarsh@gmail.com>"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "express",
+    "gulp",
+    "browserify",
+    "angular",
+    "sass",
+    "karma",
+    "jasmine",
+    "protractor",
+    "boilerplate"
+  ],
+  "homepage": "https://github.com/StrikeForceZero/dotcom",
+  "moduleType": [],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "angular": "~1.4.8",
+    "angular-ui-router": "~0.2.15",
+    "angular-mocks": "~1.4.8",
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "node": ">=0.12.x"
   },
   "devDependencies": {
-    "angular": "^1.3.15",
-    "angular-mocks": "^1.3.15",
-    "angular-ui-router": "^0.2.13",
     "babel-core": "^5.8.25",
     "babelify": "^6.3.0",
     "brfs": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -73,5 +73,21 @@
     "test": "karma start test/karma.conf.js",
     "preprotractor": "npm install && webdriver-manager update",
     "protractor": "protractor test/protractor.conf.js"
+  },
+  "browser": {
+    "jquery": "./bower_components/jquery/dist/jquery.js",
+    "angular": "./bower_components/angular/angular.js"
+  },
+  "browserify-shim": {
+    "jquery": "$",
+    "angular": { "exports": "angular", "depends": [ "jquery" ] }
+  },
+  "browserify": {
+    "transform": [
+      "browserify-shim"
+    ]
+  },
+  "dependencies": {
+    "browserify-shim": "^3.8.11"
   }
 }


### PR DESCRIPTION
Here is an example of loading jquery dependent plugins/modules in this specific case fullpage.js
In regards to jakemmarsh/angularjs-gulp-browserify-boilerplate/issues/119

I prefer to have angular in the bower deps because a lot of the time the package I'm looking for may only exist in bower and when it does it will want to pull in angular which creates a conflicts when browserify pulls them in. 

Feel free to convert it back to using node modules as the angular-fullpage module is in the npm repo already.
